### PR TITLE
Bump nix installer in update-hash.yaml

### DIFF
--- a/.github/workflows/update-hash.yaml
+++ b/.github/workflows/update-hash.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Nix
         if: steps.check-etag.outputs.changed == 'true'
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |


### PR DESCRIPTION
CI fails. Bumping nix [makes it work again](https://github.com/lierdakil/hackage.nix/actions/runs/18729027459)